### PR TITLE
Implement full CRUD operations for kanban board columns (lists)

### DIFF
--- a/project/app/(dashboard)/projects/[id]/page.tsx
+++ b/project/app/(dashboard)/projects/[id]/page.tsx
@@ -16,6 +16,7 @@ interface ProjectPage {
 
 export default function ProjectPage({ params }: ProjectPage) {
   const { id } = use(params);
+
   const [project] = useProject(id);
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -83,7 +84,7 @@ export default function ProjectPage({ params }: ProjectPage) {
         </div>
 
         {/* Kanban Board Placeholder */}
-        <KanbanBoard projectId="1" />
+        <KanbanBoard projectId={id} />
 
         {/* Component Implementation Guide */}
         <div className="mt-8 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 p-6 dark:border-gray-600 dark:bg-gray-800/50">

--- a/project/components/create-list-button.tsx
+++ b/project/components/create-list-button.tsx
@@ -16,7 +16,7 @@ export default function CreateListButton({ projectId }: CreateListButton) {
     <Fragment>
       <button
         onClick={toggleModal}
-        className="border-primary/20 text-primary flex min-h-[500px] min-w-80 cursor-pointer flex-nowrap items-center justify-center gap-2 rounded-sm border-2 border-dashed bg-neutral-50 hover:bg-neutral-700 dark:border-neutral-500 dark:bg-neutral-800 dark:text-neutral-300">
+        className="border-primary/20 text-primary hover:bg-primary/10 flex min-h-[500px] min-w-80 cursor-pointer flex-nowrap items-center justify-center gap-2 rounded-sm border-2 border-dashed bg-neutral-50 dark:border-neutral-500 dark:bg-neutral-800 dark:text-neutral-300">
         <PlusSquare size={18} />
         Add List
       </button>

--- a/project/components/create-list-button.tsx
+++ b/project/components/create-list-button.tsx
@@ -1,0 +1,32 @@
+import { ProjectSchema } from "@/types/projects";
+import { PlusSquare } from "lucide-react";
+import { Fragment, useState } from "react";
+import { CreateListModal } from "./modals/create-list-modal";
+
+interface CreateListButton {
+  projectId: ProjectSchema["id"];
+}
+
+export default function CreateListButton({ projectId }: CreateListButton) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const toggleModal = () => setIsModalOpen((prev) => !prev);
+
+  return (
+    <Fragment>
+      <button
+        onClick={toggleModal}
+        className="border-primary/20 text-primary flex min-h-[500px] min-w-80 cursor-pointer flex-nowrap items-center justify-center gap-2 rounded-sm border-2 border-dashed bg-neutral-50 hover:bg-neutral-700 dark:border-neutral-500 dark:bg-neutral-800 dark:text-neutral-300">
+        <PlusSquare size={18} />
+        Add List
+      </button>
+
+      {isModalOpen && (
+        <CreateListModal
+          projectId={projectId}
+          toggle={toggleModal}
+        />
+      )}
+    </Fragment>
+  );
+}

--- a/project/components/create-list-button.tsx
+++ b/project/components/create-list-button.tsx
@@ -3,11 +3,15 @@ import { PlusSquare } from "lucide-react";
 import { Fragment, useState } from "react";
 import { CreateListModal } from "./modals/create-list-modal";
 
-interface CreateListButton {
+interface CreateListButtonProps {
   projectId: ProjectSchema["id"];
+  refetchLists: () => void;
 }
 
-export default function CreateListButton({ projectId }: CreateListButton) {
+export default function CreateListButton({
+  projectId,
+  refetchLists
+}: CreateListButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const toggleModal = () => setIsModalOpen((prev) => !prev);
@@ -23,8 +27,9 @@ export default function CreateListButton({ projectId }: CreateListButton) {
 
       {isModalOpen && (
         <CreateListModal
-          projectId={projectId}
           toggle={toggleModal}
+          projectId={projectId}
+          refetchLists={refetchLists}
         />
       )}
     </Fragment>

--- a/project/components/kanban-board.tsx
+++ b/project/components/kanban-board.tsx
@@ -63,29 +63,6 @@ const tasks: TTaskCard[] = [
   }
 ];
 
-const initialColumns = [
-  {
-    id: "todo",
-    title: "To Do",
-    tasks
-  },
-  {
-    id: "in-progress",
-    title: "In Progress",
-    tasks
-  },
-  {
-    id: "review",
-    title: "Review",
-    tasks
-  },
-  {
-    id: "done",
-    title: "Done",
-    tasks
-  }
-];
-
 interface KanbanBoardProps {
   projectId: ProjectSchema["id"];
 }

--- a/project/components/kanban-board.tsx
+++ b/project/components/kanban-board.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TaskCard as TTaskCard } from "@/types/tasks";
+import CreateListButton from "./create-list-button";
 import ListCard from "./list-card";
 
 // TODO: Task 5.1 - Design responsive Kanban board layout
@@ -94,6 +95,7 @@ export function KanbanBoard({ projectId }: { projectId: string }) {
             tasks={list.tasks}
           />
         ))}
+        <CreateListButton projectId={projectId} />
       </div>
     </div>
   );

--- a/project/components/kanban-board.tsx
+++ b/project/components/kanban-board.tsx
@@ -3,7 +3,6 @@
 import { getListsByProjectId } from "@/lib/actions/lists";
 import { List } from "@/types/lists";
 import { ProjectSchema } from "@/types/projects";
-import { TaskCard as TTaskCard } from "@/types/tasks";
 import { useCallback, useEffect, useState } from "react";
 import CreateListButton from "./create-list-button";
 import ListCard from "./list-card";
@@ -43,25 +42,6 @@ State management:
 - Implement optimistic updates
 - Handle conflicts with server state
 */
-
-const tasks: TTaskCard[] = [
-  {
-    id: "1",
-    title: "Design homepage mockup",
-    description: "Create initial design concepts",
-    priority: "high",
-    assigneeName: "Mark Kenenth",
-    assigneeImageUrl: "/placeholder-user.jpg"
-  },
-  {
-    id: "2",
-    title: "Car dealership web",
-    description: "Create car dealership project",
-    priority: "low",
-    assigneeName: "Mark Kenenth",
-    assigneeImageUrl: "/placeholder-user.jpg"
-  }
-];
 
 interface KanbanBoardProps {
   projectId: ProjectSchema["id"];

--- a/project/components/kanban-board.tsx
+++ b/project/components/kanban-board.tsx
@@ -82,8 +82,6 @@ const initialColumns = [
 ];
 
 export function KanbanBoard({ projectId }: { projectId: string }) {
-  void projectId;
-
   return (
     <div className="outline-primary/20 w-full rounded-sm bg-white p-6 outline-2 dark:bg-neutral-800">
       <div className="flex min-w-full flex-nowrap space-x-6 overflow-x-auto pb-4">

--- a/project/components/kanban-board.tsx
+++ b/project/components/kanban-board.tsx
@@ -77,6 +77,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
             key={list.id}
             id={list.id}
             name={list.name}
+            refetchLists={refetchLists}
           />
         ))}
         <CreateListButton

--- a/project/components/kanban-board.tsx
+++ b/project/components/kanban-board.tsx
@@ -2,6 +2,7 @@
 
 import { getListsByProjectId } from "@/lib/actions/lists";
 import { List } from "@/types/lists";
+import { ProjectSchema } from "@/types/projects";
 import { TaskCard as TTaskCard } from "@/types/tasks";
 import { useCallback, useEffect, useState } from "react";
 import CreateListButton from "./create-list-button";
@@ -85,7 +86,11 @@ const initialColumns = [
   }
 ];
 
-export function KanbanBoard({ projectId }: { projectId: string }) {
+interface KanbanBoardProps {
+  projectId: ProjectSchema["id"];
+}
+
+export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [lists, setLists] = useState<List[] | null>(null);
 
   const refetchLists = useCallback(async () => {

--- a/project/components/list-card.tsx
+++ b/project/components/list-card.tsx
@@ -1,36 +1,35 @@
 import { ListSchema } from "@/types/lists";
-import { TaskCard as TTaskCard } from "@/types/tasks";
-import { MoreHorizontal, Plus } from "lucide-react";
-import Button from "./button";
-import { TaskCard } from "./task-card";
+import { Edit, MoreHorizontal, Trash } from "lucide-react";
+import Dropdown from "./drop-down";
 
 interface ListCardProps {
   id: ListSchema["id"];
-  title: ListSchema["id"];
-  tasks: TTaskCard[];
+  name: ListSchema["name"];
 }
 
-export default function ListCard({ title, tasks }: ListCardProps) {
+export default function ListCard({ id, name }: ListCardProps) {
   return (
-    <div className="border-primary/20 min-h-[500px] min-w-80 overflow-hidden rounded-sm border-3 bg-neutral-100 dark:bg-neutral-700">
+    <div className="border-primary/20 min-h-[500px] min-w-80 overflow-hidden rounded-sm border-3 bg-neutral-100 dark:bg-neutral-900">
       <div className="bg-primary px-3 py-2 dark:border-neutral-600">
         <div className="flex items-center justify-between">
           <h3 className="font-semibold text-neutral-200">
-            {title}
+            {name}
             <span className="ml-2 rounded-sm bg-white/20 px-2 py-1 text-xs">
-              {tasks.length}
+              {[1, 2].length}
             </span>
           </h3>
-          <button className="rounded p-1">
-            <MoreHorizontal
-              className="text-neutral-200"
-              size={16}
-            />
-          </button>
+          <Dropdown
+            label={<MoreHorizontal size={14} />}
+            className="cursor-pointer text-neutral-100"
+            items={[
+              { onClick: () => {}, label: "Edit", icon: Edit },
+              { onClick: () => {}, label: "Delete", icon: Trash }
+            ]}
+          />
         </div>
       </div>
 
-      <div className="space-y-3 p-4">
+      {/* <div className="space-y-3 p-4">
         {tasks.map((task, i) => (
           <TaskCard
             key={i}
@@ -41,7 +40,7 @@ export default function ListCard({ title, tasks }: ListCardProps) {
         <Button className="border-primary bg-primary/10 text-primary w-full border-1 border-dashed dark:text-neutral-200">
           <Plus size={16} /> Add Task
         </Button>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/project/components/list-card.tsx
+++ b/project/components/list-card.tsx
@@ -1,35 +1,43 @@
 import { ListSchema } from "@/types/lists";
 import { Edit, MoreHorizontal, Trash } from "lucide-react";
+import { Fragment, useState } from "react";
 import Dropdown from "./drop-down";
+import { UpdateListModal } from "./modals/update-list-modal";
 
 interface ListCardProps {
   id: ListSchema["id"];
   name: ListSchema["name"];
+  refetchLists: () => void;
 }
 
-export default function ListCard({ id, name }: ListCardProps) {
-  return (
-    <div className="border-primary/20 min-h-[500px] min-w-80 overflow-hidden rounded-sm border-3 bg-neutral-100 dark:bg-neutral-900">
-      <div className="bg-primary px-3 py-2 dark:border-neutral-600">
-        <div className="flex items-center justify-between">
-          <h3 className="font-semibold text-neutral-200">
-            {name}
-            <span className="ml-2 rounded-sm bg-white/20 px-2 py-1 text-xs">
-              {[1, 2].length}
-            </span>
-          </h3>
-          <Dropdown
-            label={<MoreHorizontal size={14} />}
-            className="cursor-pointer text-neutral-100"
-            items={[
-              { onClick: () => {}, label: "Edit", icon: Edit },
-              { onClick: () => {}, label: "Delete", icon: Trash }
-            ]}
-          />
-        </div>
-      </div>
+export default function ListCard({ id, name, refetchLists }: ListCardProps) {
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-      {/* <div className="space-y-3 p-4">
+  const toggleEditModalOpen = () => setIsEditModalOpen((prev) => !prev);
+
+  return (
+    <Fragment>
+      <div className="border-primary/20 min-h-[500px] min-w-80 overflow-hidden rounded-sm border-3 bg-neutral-100 dark:bg-neutral-900">
+        <div className="bg-primary px-3 py-2 dark:border-neutral-600">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-neutral-200">
+              {name}
+              <span className="ml-2 rounded-sm bg-white/20 px-2 py-1 text-xs">
+                {[1, 2].length}
+              </span>
+            </h3>
+            <Dropdown
+              label={<MoreHorizontal size={14} />}
+              className="cursor-pointer text-neutral-100"
+              items={[
+                { onClick: toggleEditModalOpen, label: "Edit", icon: Edit },
+                { onClick: () => {}, label: "Delete", icon: Trash }
+              ]}
+            />
+          </div>
+        </div>
+
+        {/* <div className="space-y-3 p-4">
         {tasks.map((task, i) => (
           <TaskCard
             key={i}
@@ -41,6 +49,15 @@ export default function ListCard({ id, name }: ListCardProps) {
           <Plus size={16} /> Add Task
         </Button>
       </div> */}
-    </div>
+      </div>
+
+      {isEditModalOpen && (
+        <UpdateListModal
+          id={id}
+          refetchLists={refetchLists}
+          toggle={toggleEditModalOpen}
+        />
+      )}
+    </Fragment>
   );
 }

--- a/project/components/list-card.tsx
+++ b/project/components/list-card.tsx
@@ -12,7 +12,7 @@ interface ListCardProps {
 
 export default function ListCard({ title, tasks }: ListCardProps) {
   return (
-    <div className="border-primary/20 min-w-80 overflow-hidden rounded-sm border-3 bg-neutral-100 dark:bg-neutral-700">
+    <div className="border-primary/20 min-h-[500px] min-w-80 overflow-hidden rounded-sm border-3 bg-neutral-100 dark:bg-neutral-700">
       <div className="bg-primary px-3 py-2 dark:border-neutral-600">
         <div className="flex items-center justify-between">
           <h3 className="font-semibold text-neutral-200">
@@ -30,7 +30,7 @@ export default function ListCard({ title, tasks }: ListCardProps) {
         </div>
       </div>
 
-      <div className="min-h-[400px] space-y-3 p-4">
+      <div className="space-y-3 p-4">
         {tasks.map((task, i) => (
           <TaskCard
             key={i}

--- a/project/components/list-card.tsx
+++ b/project/components/list-card.tsx
@@ -2,6 +2,7 @@ import { ListSchema } from "@/types/lists";
 import { Edit, MoreHorizontal, Trash } from "lucide-react";
 import { Fragment, useState } from "react";
 import Dropdown from "./drop-down";
+import { DeleteListModal } from "./modals/delete-list-modal";
 import { UpdateListModal } from "./modals/update-list-modal";
 
 interface ListCardProps {
@@ -12,8 +13,15 @@ interface ListCardProps {
 
 export default function ListCard({ id, name, refetchLists }: ListCardProps) {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const toggleEditModalOpen = () => setIsEditModalOpen((prev) => !prev);
+  const toggleDeleteModalOpen = () => setIsDeleteModalOpen((prev) => !prev);
+
+  const dropdownItems = [
+    { onClick: toggleEditModalOpen, label: "Edit", icon: Edit },
+    { onClick: toggleDeleteModalOpen, label: "Delete", icon: Trash }
+  ];
 
   return (
     <Fragment>
@@ -29,10 +37,7 @@ export default function ListCard({ id, name, refetchLists }: ListCardProps) {
             <Dropdown
               label={<MoreHorizontal size={14} />}
               className="cursor-pointer text-neutral-100"
-              items={[
-                { onClick: toggleEditModalOpen, label: "Edit", icon: Edit },
-                { onClick: () => {}, label: "Delete", icon: Trash }
-              ]}
+              items={dropdownItems}
             />
           </div>
         </div>
@@ -56,6 +61,14 @@ export default function ListCard({ id, name, refetchLists }: ListCardProps) {
           id={id}
           refetchLists={refetchLists}
           toggle={toggleEditModalOpen}
+        />
+      )}
+
+      {isDeleteModalOpen && (
+        <DeleteListModal
+          listId={id}
+          refetchLists={refetchLists}
+          toggle={toggleDeleteModalOpen}
         />
       )}
     </Fragment>

--- a/project/components/modals/create-list-modal.tsx
+++ b/project/components/modals/create-list-modal.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import { createList } from "@/lib/actions/lists";
 import { ProjectSchema } from "@/types/projects";
 import { useUser } from "@clerk/nextjs";
-import { SquareArrowLeft, TriangleAlert } from "lucide-react";
+import { GitCommitHorizontal, GitGraph } from "lucide-react";
 import { ChangeEvent, MouseEvent, useState } from "react";
 import Button from "../button";
 import Input from "../input";
 import Radio from "../radio";
+import { showErrorToast, showSuccessToast } from "../toast";
 import Modal from "./modal";
 
 interface CreateProjectModalProps {
@@ -32,13 +34,17 @@ export function CreateListModal({
     if (!user?.id) return;
 
     const payload = {
-      userId: user.id,
+      projectId,
       name: formData.name,
-      projectId: projectId,
-      isFinal: formData.listType === "terminal"
+      isFinal: formData.listType === "terminal",
+      userClerkId: user.id
     };
 
-    console.log(payload);
+    const { success, message } = await createList(payload);
+    if (!success) return showErrorToast(message);
+
+    showSuccessToast(message);
+    toggle();
   };
 
   return (
@@ -62,7 +68,7 @@ export function CreateListModal({
             value="progress"
             title="Progress"
             description="Mark tasks in progress."
-            icon={TriangleAlert}
+            icon={GitGraph}
             checked={formData.listType === "progress"}
             onChange={handleChange}
           />
@@ -73,7 +79,7 @@ export function CreateListModal({
             value="terminal"
             title="Terminal"
             description="Mark tasks as final."
-            icon={SquareArrowLeft}
+            icon={GitCommitHorizontal}
             checked={formData.listType === "terminal"}
             onChange={handleChange}
           />

--- a/project/components/modals/create-list-modal.tsx
+++ b/project/components/modals/create-list-modal.tsx
@@ -11,7 +11,7 @@ import Radio from "../radio";
 import { showErrorToast, showSuccessToast } from "../toast";
 import Modal from "./modal";
 
-interface CreateProjectModalProps {
+interface CreateListModalProps {
   toggle: () => void;
   projectId: ProjectSchema["id"];
   refetchLists: () => void;
@@ -21,7 +21,7 @@ export function CreateListModal({
   toggle,
   projectId,
   refetchLists
-}: CreateProjectModalProps) {
+}: CreateListModalProps) {
   const { user } = useUser();
   const [formData, setFormData] = useState({ name: "", listType: "progress" });
 

--- a/project/components/modals/create-list-modal.tsx
+++ b/project/components/modals/create-list-modal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { ProjectSchema } from "@/types/projects";
+import { useUser } from "@clerk/nextjs";
+import { SquareArrowLeft, TriangleAlert } from "lucide-react";
+import { ChangeEvent, MouseEvent, useState } from "react";
+import Button from "../button";
+import Input from "../input";
+import Radio from "../radio";
+import Modal from "./modal";
+
+interface CreateProjectModalProps {
+  toggle: () => void;
+  projectId: ProjectSchema["id"];
+}
+
+export function CreateListModal({
+  projectId,
+  toggle
+}: CreateProjectModalProps) {
+  const { user } = useUser();
+  const [formData, setFormData] = useState({ name: "", listType: "progress" });
+
+  const handleChange = (evt: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = evt.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCreateList = async (evt: MouseEvent<HTMLButtonElement>) => {
+    evt.preventDefault();
+
+    if (!user?.id) return;
+
+    const payload = {
+      userId: user.id,
+      name: formData.name,
+      projectId: projectId,
+      isFinal: formData.listType === "terminal"
+    };
+
+    console.log(payload);
+  };
+
+  return (
+    <Modal
+      toggle={toggle}
+      title="Create Board List">
+      <form className="space-y-4">
+        <Input
+          id="name"
+          name="name"
+          label="List Name"
+          placeholder="Enter list name"
+          value={formData.name}
+          onChange={handleChange}
+        />
+
+        <div className="flex gap-3">
+          <Radio
+            id="progress"
+            name="listType"
+            value="progress"
+            title="Progress"
+            description="Mark tasks in progress."
+            icon={TriangleAlert}
+            checked={formData.listType === "progress"}
+            onChange={handleChange}
+          />
+
+          <Radio
+            id="terminal"
+            name="listType"
+            value="terminal"
+            title="Terminal"
+            description="Mark tasks as final."
+            icon={SquareArrowLeft}
+            checked={formData.listType === "terminal"}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="flex justify-end space-x-3 pt-4">
+          <Button
+            type="button"
+            onClick={toggle}
+            className="text-neutral-800 dark:text-neutral-100">
+            Cancel
+          </Button>
+
+          <Button
+            type="button"
+            onClick={handleCreateList}
+            className="bg-primary text-neutral-100">
+            Create List
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/project/components/modals/create-list-modal.tsx
+++ b/project/components/modals/create-list-modal.tsx
@@ -14,11 +14,13 @@ import Modal from "./modal";
 interface CreateProjectModalProps {
   toggle: () => void;
   projectId: ProjectSchema["id"];
+  refetchLists: () => void;
 }
 
 export function CreateListModal({
+  toggle,
   projectId,
-  toggle
+  refetchLists
 }: CreateProjectModalProps) {
   const { user } = useUser();
   const [formData, setFormData] = useState({ name: "", listType: "progress" });
@@ -44,6 +46,7 @@ export function CreateListModal({
     if (!success) return showErrorToast(message);
 
     showSuccessToast(message);
+    refetchLists();
     toggle();
   };
 

--- a/project/components/modals/delete-list-modal.tsx
+++ b/project/components/modals/delete-list-modal.tsx
@@ -1,0 +1,76 @@
+import { deleteList } from "@/lib/actions/lists";
+import { ListSchema } from "@/types/lists";
+import { useUser } from "@clerk/nextjs";
+import { ChangeEvent, useState } from "react";
+import Button from "../button";
+import Input from "../input";
+import { showErrorToast, showSuccessToast } from "../toast";
+import Modal from "./modal";
+
+interface DeleteListModalProps {
+  toggle: () => void;
+  listId: ListSchema["id"];
+  refetchLists: () => void;
+}
+
+export function DeleteListModal({
+  toggle,
+  listId,
+  refetchLists
+}: DeleteListModalProps) {
+  const TARGET_CONFIRM_TEXT = "DELETE LIST";
+
+  const { user } = useUser();
+  const [confirmText, setConfirmText] = useState("");
+
+  const handleConfirmChange = (evt: ChangeEvent<HTMLInputElement>) => {
+    setConfirmText(evt.target.value);
+  };
+
+  const handleDeleteList = async () => {
+    if (!user?.id) return null;
+
+    if (confirmText !== TARGET_CONFIRM_TEXT) {
+      return showErrorToast("Wrong delete confirmation value.");
+    }
+
+    const { success, message } = await deleteList({
+      id: listId,
+      userClerkId: user.id
+    });
+
+    if (!success) return showErrorToast(message);
+    showSuccessToast(message);
+
+    toggle();
+    refetchLists();
+  };
+
+  return (
+    <Modal
+      toggle={toggle}
+      title="Delete List">
+      <div className="space-y-3">
+        <Input
+          id="confirm-delete"
+          value={confirmText}
+          placeholder="DELETE LIST"
+          onChange={handleConfirmChange}
+          label={`Type ${TARGET_CONFIRM_TEXT} to delete this list.`}
+        />
+        <div className="flex justify-end gap-2">
+          <Button
+            onClick={toggle}
+            className="bg-neutral-200 text-neutral-800 dark:bg-neutral-900 dark:text-neutral-100">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDeleteList}
+            className="bg-red-700 text-neutral-100">
+            Delete List
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/project/components/modals/update-list-modal.tsx
+++ b/project/components/modals/update-list-modal.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { getListById, updateList } from "@/lib/actions/lists";
+import { ProjectSchema } from "@/types/projects";
+import { useUser } from "@clerk/nextjs";
+import { GitCommitHorizontal, GitGraph } from "lucide-react";
+import {
+  ChangeEvent,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useState
+} from "react";
+import Button from "../button";
+import Input from "../input";
+import Radio from "../radio";
+import { showErrorToast, showSuccessToast } from "../toast";
+import Modal from "./modal";
+
+interface UpdateListModalProps {
+  toggle: () => void;
+  id: ProjectSchema["id"];
+  refetchLists: () => void;
+}
+
+export function UpdateListModal({
+  id,
+  toggle,
+  refetchLists
+}: UpdateListModalProps) {
+  const { user } = useUser();
+  const [formData, setFormData] = useState({ name: "", listType: "progress" });
+
+  const handleChange = (evt: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = evt.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleUpdateList = async (evt: MouseEvent<HTMLButtonElement>) => {
+    evt.preventDefault();
+
+    if (!user?.id) return;
+
+    const payload = {
+      id,
+      name: formData.name,
+      isFinal: formData.listType === "terminal",
+      userClerkId: user.id
+    };
+
+    const { success, message } = await updateList(payload);
+    if (!success) return showErrorToast(message);
+
+    showSuccessToast(message);
+    refetchLists();
+    toggle();
+  };
+
+  const fetchListData = useCallback(async () => {
+    const { success, message, list } = await getListById(id);
+
+    if (!success || !list) return showErrorToast(message);
+
+    setFormData({
+      name: list.name,
+      listType: list.isFinal ? "terminal" : "progress"
+    });
+  }, [id]);
+
+  useEffect(() => {
+    fetchListData();
+  }, [fetchListData]);
+
+  return (
+    <Modal
+      toggle={toggle}
+      title="Update Board List">
+      <form className="space-y-4">
+        <Input
+          id="name"
+          name="name"
+          label="List Name"
+          placeholder="Enter list name"
+          value={formData.name}
+          onChange={handleChange}
+        />
+
+        <div className="flex gap-3">
+          <Radio
+            id="progress"
+            name="listType"
+            value="progress"
+            title="Progress"
+            description="Mark tasks in progress."
+            icon={GitGraph}
+            checked={formData.listType === "progress"}
+            onChange={handleChange}
+          />
+
+          <Radio
+            id="terminal"
+            name="listType"
+            value="terminal"
+            title="Terminal"
+            description="Mark tasks as final."
+            icon={GitCommitHorizontal}
+            checked={formData.listType === "terminal"}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="flex justify-end space-x-3 pt-4">
+          <Button
+            type="button"
+            onClick={toggle}
+            className="text-neutral-800 dark:text-neutral-100">
+            Cancel
+          </Button>
+
+          <Button
+            type="button"
+            onClick={handleUpdateList}
+            className="bg-primary text-neutral-100">
+            Update List
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/project/components/radio.tsx
+++ b/project/components/radio.tsx
@@ -20,7 +20,7 @@ export default function Radio({
   ...props
 }: RadioCardProps) {
   return (
-    <div>
+    <div className="w-full">
       <input
         id={id}
         name={name}

--- a/project/components/radio.tsx
+++ b/project/components/radio.tsx
@@ -1,0 +1,54 @@
+import type { LucideIcon } from "lucide-react";
+import { InputHTMLAttributes } from "react";
+
+interface RadioCardProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  name: string;
+  value: string;
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+}
+
+export default function Radio({
+  id,
+  name,
+  value,
+  title,
+  description,
+  icon: Icon,
+  ...props
+}: RadioCardProps) {
+  return (
+    <div>
+      <input
+        id={id}
+        name={name}
+        value={value}
+        type="radio"
+        className="peer hidden"
+        {...props}
+      />
+      <label
+        htmlFor={id}
+        className="border-primary/20 peer-checked:border-primary peer-checked:bg-primary/5 peer-checked:text-primary dark:peer-checked:border-primary/50 inline-flex w-full cursor-pointer items-center justify-between rounded-sm border-2 text-gray-500 hover:bg-gray-50 hover:text-gray-600 dark:text-gray-400 dark:peer-checked:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-300">
+        <div className="flex items-start space-x-3 p-2">
+          {Icon && (
+            <Icon
+              size={16}
+              className="mt-1"
+            />
+          )}
+          <div>
+            <div className="font-semibold">{title}</div>
+            {description && (
+              <div className="text-xs text-gray-400 dark:text-gray-500">
+                {description}
+              </div>
+            )}
+          </div>
+        </div>
+      </label>
+    </div>
+  );
+}

--- a/project/lib/actions/lists.ts
+++ b/project/lib/actions/lists.ts
@@ -131,3 +131,29 @@ export async function getListById(id: ListSchema["id"]) {
     return { success: false, message: "Error. Cannot get list." };
   }
 }
+
+interface DeleteListParams {
+  id: ListSchema["id"];
+  userClerkId: UserSchema["clerkId"];
+}
+
+export async function deleteList({ id, userClerkId }: DeleteListParams) {
+  try {
+    const validClerkId = userClerkIdSchema.parse(userClerkId);
+    const validListId = listIdSchema.parse(id);
+    const validUserId = await userQueries.getIdByClerkId(validClerkId);
+
+    if (!(await isUserListCreator(validListId, validUserId))) {
+      return { success: false, message: "You are not the owner if this list." };
+    }
+
+    await listQueries.delete(validListId);
+    return { success: true, message: "List deleted successfully." };
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return { success: false, message: error.issues[0].message };
+    }
+
+    return { success: false, message: "Error. Cannot delete list." };
+  }
+}

--- a/project/lib/actions/lists.ts
+++ b/project/lib/actions/lists.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { ListSchema } from "@/types/lists";
+import { UserSchema } from "@/types/users";
+import { ZodError } from "zod";
+import listQueries from "../db/queries/lists";
+import userQueries from "../db/queries/users";
+import { isUserProjectOwner } from "../utils/projects";
+import { createListSchema } from "../validations/lists";
+import { userClerkIdSchema } from "../validations/users";
+
+export interface CreateListPayload
+  extends Pick<ListSchema, "name" | "isFinal" | "projectId"> {
+  userClerkId: UserSchema["clerkId"];
+}
+
+export async function createList(payload: CreateListPayload) {
+  try {
+    const { projectId, name, isFinal, userClerkId } = payload;
+
+    // Validate user Clerk ID
+    const validUserClerkId = userClerkIdSchema.parse(userClerkId);
+    const userId = await userQueries.getIdByClerkId(validUserClerkId); // Get the user ID in DB
+
+    // Check if user is a project owner
+    if (!(await isUserProjectOwner(userId, projectId))) {
+      return { success: false, message: "You are not the project owner." };
+    }
+
+    const createData = { projectId, name, isFinal, createdBy: userId };
+
+    // Validate create list data
+    const valid = createListSchema.parse(createData);
+
+    // Create data
+    await listQueries.create(valid);
+
+    return { success: true, message: "List created successfully." };
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return { success: false, message: error.issues[0].message };
+    }
+
+    console.log(error);
+
+    return { success: false, message: "Error. Cannot create list." };
+  }
+}

--- a/project/lib/db/drizzle/migrations/0000_red_mother_askani.sql
+++ b/project/lib/db/drizzle/migrations/0000_red_mother_askani.sql
@@ -34,16 +34,6 @@ CREATE TABLE "users" (
 	CONSTRAINT "users_clerkId_key" UNIQUE("clerkId")
 );
 --> statement-breakpoint
-CREATE TABLE "lists" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"name" text NOT NULL,
-	"projectId" uuid NOT NULL,
-	"position" integer NOT NULL,
-	"createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
-	"updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
-	"isFinal" boolean DEFAULT false
-);
---> statement-breakpoint
 CREATE TABLE "projects" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"name" text NOT NULL,
@@ -53,6 +43,17 @@ CREATE TABLE "projects" (
 	"updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
 	"dueDate" date NOT NULL,
 	"active" boolean DEFAULT true
+);
+--> statement-breakpoint
+CREATE TABLE "lists" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"projectId" uuid NOT NULL,
+	"position" integer,
+	"createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+	"updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+	"isFinal" boolean DEFAULT false,
+	"createdBy" uuid NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "teams" (
@@ -68,8 +69,9 @@ ALTER TABLE "tasks" ADD CONSTRAINT "listTask" FOREIGN KEY ("listId") REFERENCES 
 ALTER TABLE "tasks" ADD CONSTRAINT "taskAssignee" FOREIGN KEY ("assigneeId") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "comments" ADD CONSTRAINT "taskComment" FOREIGN KEY ("taskId") REFERENCES "public"."tasks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "comments" ADD CONSTRAINT "commentAuthor" FOREIGN KEY ("authorId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "lists" ADD CONSTRAINT "projectList" FOREIGN KEY ("projectId") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "projects" ADD CONSTRAINT "projectOwner" FOREIGN KEY ("ownerId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lists" ADD CONSTRAINT "projectList" FOREIGN KEY ("projectId") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lists" ADD CONSTRAINT "userList" FOREIGN KEY ("createdBy") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "teams" ADD CONSTRAINT "memberUserData" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "teams" ADD CONSTRAINT "projectMember" FOREIGN KEY ("projectId") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
 */

--- a/project/lib/db/drizzle/migrations/meta/0000_snapshot.json
+++ b/project/lib/db/drizzle/migrations/meta/0000_snapshot.json
@@ -251,80 +251,6 @@
       "policies": {},
       "isRLSEnabled": false
     },
-    "public.lists": {
-      "name": "lists",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "projectId": {
-          "name": "projectId",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "position": {
-          "name": "position",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "updatedAt": {
-          "name": "updatedAt",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "isFinal": {
-          "name": "isFinal",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "projectList": {
-          "name": "projectList",
-          "tableFrom": "lists",
-          "tableTo": "projects",
-          "schemaTo": "public",
-          "columnsFrom": [
-            "projectId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {},
-      "policies": {},
-      "isRLSEnabled": false
-    },
     "public.projects": {
       "name": "projects",
       "schema": "",
@@ -391,6 +317,100 @@
           "schemaTo": "public",
           "columnsFrom": [
             "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "isFinal": {
+          "name": "isFinal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projectList": {
+          "name": "projectList",
+          "tableFrom": "lists",
+          "tableTo": "projects",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "userList": {
+          "name": "userList",
+          "tableFrom": "lists",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "createdBy"
           ],
           "columnsTo": [
             "id"

--- a/project/lib/db/drizzle/migrations/meta/_journal.json
+++ b/project/lib/db/drizzle/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1754380089632,
-      "tag": "0000_petite_angel",
+      "when": 1754467971317,
+      "tag": "0000_red_mother_askani",
       "breakpoints": true
     }
   ]

--- a/project/lib/db/drizzle/migrations/relations.ts
+++ b/project/lib/db/drizzle/migrations/relations.ts
@@ -19,12 +19,17 @@ export const listsRelations = relations(lists, ({one, many}) => ({
 		fields: [lists.projectId],
 		references: [projects.id]
 	}),
+	user: one(users, {
+		fields: [lists.createdBy],
+		references: [users.id]
+	}),
 }));
 
 export const usersRelations = relations(users, ({many}) => ({
 	tasks: many(tasks),
 	comments: many(comments),
 	projects: many(projects),
+	lists: many(lists),
 	teams: many(teams),
 }));
 
@@ -40,11 +45,11 @@ export const commentsRelations = relations(comments, ({one}) => ({
 }));
 
 export const projectsRelations = relations(projects, ({one, many}) => ({
-	lists: many(lists),
 	user: one(users, {
 		fields: [projects.ownerId],
 		references: [users.id]
 	}),
+	lists: many(lists),
 	teams: many(teams),
 }));
 

--- a/project/lib/db/drizzle/migrations/schema.ts
+++ b/project/lib/db/drizzle/migrations/schema.ts
@@ -59,22 +59,6 @@ export const users = pgTable("users", {
 	unique("users_clerkId_key").on(table.clerkId),
 ]);
 
-export const lists = pgTable("lists", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	name: text().notNull(),
-	projectId: uuid().notNull(),
-	position: integer().notNull(),
-	createdAt: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`),
-	updatedAt: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`),
-	isFinal: boolean().default(false),
-}, (table) => [
-	foreignKey({
-			columns: [table.projectId],
-			foreignColumns: [projects.id],
-			name: "projectList"
-		}).onDelete("cascade"),
-]);
-
 export const projects = pgTable("projects", {
 	id: uuid().defaultRandom().primaryKey().notNull(),
 	name: text().notNull(),
@@ -89,6 +73,28 @@ export const projects = pgTable("projects", {
 			columns: [table.ownerId],
 			foreignColumns: [users.id],
 			name: "projectOwner"
+		}).onDelete("cascade"),
+]);
+
+export const lists = pgTable("lists", {
+	id: uuid().defaultRandom().primaryKey().notNull(),
+	name: text().notNull(),
+	projectId: uuid().notNull(),
+	position: integer(),
+	createdAt: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`),
+	updatedAt: timestamp({ withTimezone: true, mode: 'string' }).default(sql`CURRENT_TIMESTAMP`),
+	isFinal: boolean().default(false),
+	createdBy: uuid().notNull(),
+}, (table) => [
+	foreignKey({
+			columns: [table.projectId],
+			foreignColumns: [projects.id],
+			name: "projectList"
+		}).onDelete("cascade"),
+	foreignKey({
+			columns: [table.createdBy],
+			foreignColumns: [users.id],
+			name: "userList"
 		}).onDelete("cascade"),
 ]);
 

--- a/project/lib/db/queries/lists.ts
+++ b/project/lib/db/queries/lists.ts
@@ -11,6 +11,7 @@ const listQueries = {
     const [list] = await db.select().from(lists).where(eq(lists.id, id));
     return list;
   },
+
   create: async (data: CreateListData) => {
     const [newList] = await db
       .insert(lists)
@@ -19,6 +20,7 @@ const listQueries = {
 
     return newList.id;
   },
+
   update: async (id: ListSchema["id"], data: UpdateListPayload) => {
     const [updatedList] = await db
       .update(lists)

--- a/project/lib/db/queries/lists.ts
+++ b/project/lib/db/queries/lists.ts
@@ -45,13 +45,9 @@ const listQueries = {
 
     return updatedList.id;
   },
-  delete: async (id: ListSchema["id"]) => {
-    const [deletedList] = await db
-      .delete(lists)
-      .where(eq(lists.id, id))
-      .returning({ id: lists.id, name: lists.name });
 
-    return deletedList;
+  delete: async (id: ListSchema["id"]) => {
+    await db.delete(lists).where(eq(lists.id, id));
   }
 };
 

--- a/project/lib/db/queries/lists.ts
+++ b/project/lib/db/queries/lists.ts
@@ -1,5 +1,6 @@
 import { lists } from "@/lib/db/drizzle/migrations/schema";
 import { CreateListData, ListSchema, UpdateListPayload } from "@/types/lists";
+import { ProjectSchema } from "@/types/projects";
 import { eq } from "drizzle-orm";
 import db from "..";
 
@@ -7,9 +8,14 @@ const listQueries = {
   getAll: async () => {
     return await db.select().from(lists);
   },
+
   getById: async (id: ListSchema["id"]) => {
     const [list] = await db.select().from(lists).where(eq(lists.id, id));
     return list;
+  },
+
+  getByProjectId: async (projectId: ProjectSchema["id"]) => {
+    return await db.select().from(lists).where(eq(lists.projectId, projectId));
   },
 
   create: async (data: CreateListData) => {

--- a/project/lib/db/queries/lists.ts
+++ b/project/lib/db/queries/lists.ts
@@ -1,5 +1,5 @@
 import { lists } from "@/lib/db/drizzle/migrations/schema";
-import { CreateListData, ListSchema, UpdateListPayload } from "@/types/lists";
+import { CreateListData, ListSchema, UpdateListData } from "@/types/lists";
 import { ProjectSchema } from "@/types/projects";
 import { eq } from "drizzle-orm";
 import db from "..";
@@ -18,6 +18,15 @@ const listQueries = {
     return await db.select().from(lists).where(eq(lists.projectId, projectId));
   },
 
+  getCreatorId: async (id: ListSchema["id"]) => {
+    const [result] = await db
+      .select({ createdBy: lists.createdBy })
+      .from(lists)
+      .where(eq(lists.id, id));
+
+    return result.createdBy;
+  },
+
   create: async (data: CreateListData) => {
     const [newList] = await db
       .insert(lists)
@@ -27,7 +36,7 @@ const listQueries = {
     return newList.id;
   },
 
-  update: async (id: ListSchema["id"], data: UpdateListPayload) => {
+  update: async (id: ListSchema["id"], data: UpdateListData) => {
     const [updatedList] = await db
       .update(lists)
       .set(data)

--- a/project/lib/utils/lists.ts
+++ b/project/lib/utils/lists.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { ListSchema } from "@/types/lists";
+import { UserSchema } from "@/types/users";
+import listQueries from "../db/queries/lists";
+
+export async function isUserListCreator(
+  listId: ListSchema["id"],
+  userId: UserSchema["id"]
+) {
+  const createdBy = await listQueries.getCreatorId(listId);
+  return userId === createdBy;
+}

--- a/project/lib/validations/lists.ts
+++ b/project/lib/validations/lists.ts
@@ -18,12 +18,10 @@ export const updateListSchema = z.object({
   name: z
     .string("List name must be string.")
     .trim()
-    .max(MAX_NAME, `Max list name length is ${MAX_NAME} characters.`),
-  projectId: z.uuidv4("Project ID must be a UUID."),
-  position: z
-    .number("Position must be a number.")
-    .positive("Invalid position."),
-  updatedAt: z.iso.datetime("Invalid date for date modified.")
+    .min(MIN_NAME, `Minimum list name length is ${MIN_NAME} characters.`)
+    .max(MAX_NAME, `Maximum list name length is ${MAX_NAME} characters.`),
+  updatedAt: z.iso.datetime("Invalid date for date modified."),
+  isFinal: z.boolean("isFinal field must be boolean.")
 });
 
-export const listIdSchema = z.uuidv4("Comment ID is an invalid UUID.");
+export const listIdSchema = z.uuidv4("List ID is an invalid UUID.");

--- a/project/lib/validations/lists.ts
+++ b/project/lib/validations/lists.ts
@@ -1,14 +1,17 @@
 import z from "zod";
 
-const MAX_NAME = 10;
+const MAX_NAME = 20;
+const MIN_NAME = 3;
 
 export const createListSchema = z.object({
   name: z
     .string("List name must be string.")
     .trim()
-    .max(MAX_NAME, `Max list name length is ${MAX_NAME} characters.`),
+    .min(MIN_NAME, `Minimum list name length is ${MIN_NAME} characters.`)
+    .max(MAX_NAME, `Maximum list name length is ${MAX_NAME} characters.`),
   projectId: z.uuidv4("Project ID must be a UUID."),
-  position: z.number("Position must be a number.").positive("Invalid position.")
+  createdBy: z.uuidv4("List creator ID must be UUID."),
+  isFinal: z.boolean("isFinal field must be boolean.")
 });
 
 export const updateListSchema = z.object({

--- a/project/types/lists.d.ts
+++ b/project/types/lists.d.ts
@@ -11,7 +11,5 @@ export interface List extends InferSelectModel<typeof lists> {}
 export interface CreateListData
   extends Pick<ListSchema, "name" | "isFinal" | "projectId" | "createdBy"> {}
 
-export type UpdateListPayload = Pick<
-  ListSchema,
-  "name" | "position" | "isFinal" | "projectId" | "updatedAt"
->;
+export interface UpdateListData
+  extends Pick<ListSchema, "name" | "isFinal" | "updatedAt"> {}

--- a/project/types/lists.d.ts
+++ b/project/types/lists.d.ts
@@ -8,10 +8,8 @@ export interface ListSchema extends InferSelectModel<typeof lists> {
 
 export interface List extends InferSelectModel<typeof lists> {}
 
-export type CreateListData = Pick<
-  ListSchema,
-  "name" | "position" | "isFinal" | "projectId"
->;
+export interface CreateListData
+  extends Pick<ListSchema, "name" | "isFinal" | "projectId" | "createdBy"> {}
 
 export type UpdateListPayload = Pick<
   ListSchema,


### PR DESCRIPTION
This pull request introduces full CRUD functionality for **lists (kanban board columns)**, completing the core features needed to manage board columns effectively.

#### ✅ What's Included:

* **Create List**

  * Modal UI for creating new lists
  * Server actions for creating list

* **Retrieve Lists**

  * Modal UI for lists retrieval
  * Server actions for getting lists
 
* **Update List**

  * Modal UI for updating lists
  * Server actions for updating lists
 
* **Delete List**

  * Modal UI for delete lists
  * Server actions for deleting lists

#### 🧹 Additional Changes:

* Cleaned up unused placeholder data and task structures
* Fixed typo in interface name
* Added `createdBy` column to the `lists` table for ownership tracking