### PR TITLE
hotfix: add touch sensor to kanban board

### DIFF
--- a/project/components/ui/kanban/kanban-board.tsx
+++ b/project/components/ui/kanban/kanban-board.tsx
@@ -15,7 +15,11 @@ import {
   DragOverEvent,
   DragOverlay,
   DragStartEvent,
-  UniqueIdentifier
+  MouseSensor,
+  TouchSensor,
+  UniqueIdentifier,
+  useSensor,
+  useSensors
 } from "@dnd-kit/core";
 import {
   horizontalListSortingStrategy,
@@ -303,12 +307,15 @@ function KanbanItems({ projectId, lists }: KanbanItemsProps) {
     }
   };
 
+  const sensors = useSensors(useSensor(TouchSensor), useSensor(MouseSensor));
+
   useEffect(() => {
     setListsData(lists);
   }, [lists]);
 
   return (
     <DndContext
+      sensors={sensors}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}>

--- a/project/components/ui/kanban/list-card.tsx
+++ b/project/components/ui/kanban/list-card.tsx
@@ -54,7 +54,7 @@ export default function ListCard({
     <div
       style={style}
       ref={setNodeRef}
-      className="flex max-h-[600px] min-h-[500px] max-w-95 min-w-95 flex-col gap-3 overflow-auto duration-100">
+      className="flex max-h-[600px] min-h-[500px] max-w-75 min-w-75 flex-col gap-3 overflow-auto duration-100 md:max-w-95 md:min-w-95">
       <div className="bg-primary flex items-center justify-between rounded-t-sm px-4 py-3">
         <div className="flex items-center gap-3">
           <p className="flex items-center gap-2 font-bold text-neutral-100">


### PR DESCRIPTION
This PR addresses an issue where the Kanban board was not draggable for touch device users.